### PR TITLE
Refactoring codes based on the expect usage rule

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod problem7;
 mod problem8;
 mod problem9;
 use std::env;
+use std::num::ParseIntError;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -34,38 +35,38 @@ fn main() {
         return;
     }
 
-    let problem_number: u32 = args[1]
-        .trim()
-        .parse()
-        .expect("Please provide a valid number");
+    let problem_number: Result<u32, ParseIntError> = args[1].trim().parse();
 
     match problem_number {
-        1 => problem1::solve(),
-        2 => problem2::solve(),
-        3 => problem3::solve(),
-        4 => problem4::solve(),
-        5 => problem5::solve(),
-        6 => problem6::solve(),
-        7 => problem7::solve(),
-        8 => problem8::solve(),
-        9 => problem9::solve(),
-        10 => problem10::solve(),
-        11 => problem11::solve(),
-        12 => problem12::solve(),
-        13 => problem13::solve(),
-        14 => problem14::solve(),
-        15 => problem15::solve(),
-        16 => problem16::solve(),
-        17 => problem17::solve(),
-        18 => problem18::solve(),
-        19 => problem19::solve(),
-        20 => problem20::solve(),
-        21 => problem21::solve(),
-        22 => problem22::solve(),
-        23 => problem23::solve(),
-        24 => problem24::solve(),
-        25 => problem25::solve(),
-        26 => problem26::solve(),
-        _ => println!("Problem not found"),
+        Ok(num) => match num {
+            1 => problem1::solve(),
+            2 => problem2::solve(),
+            3 => problem3::solve(),
+            4 => problem4::solve(),
+            5 => problem5::solve(),
+            6 => problem6::solve(),
+            7 => problem7::solve(),
+            8 => problem8::solve(),
+            9 => problem9::solve(),
+            10 => problem10::solve(),
+            11 => problem11::solve(),
+            12 => problem12::solve(),
+            13 => problem13::solve(),
+            14 => problem14::solve(),
+            15 => problem15::solve(),
+            16 => problem16::solve(),
+            17 => problem17::solve(),
+            18 => problem18::solve(),
+            19 => problem19::solve(),
+            20 => problem20::solve(),
+            21 => problem21::solve(),
+            22 => problem22::solve(),
+            23 => problem23::solve(),
+            24 => problem24::solve(),
+            25 => problem25::solve(),
+            26 => problem26::solve(),
+            _ => println!("Problem not found"),
+        },
+        Err(e) => println!("Error parsing problem number: {e}"),
     }
 }

--- a/src/problem14.rs
+++ b/src/problem14.rs
@@ -1,12 +1,6 @@
 // Problem 14. Maximum Number of Words Found in Sentences
-fn most_words_found(sentences: &[String]) -> i32 {
-    sentences
-        .iter()
-        .map(|x| {
-            i32::try_from(x.split_whitespace().count()).expect("Failed to convert count to i32")
-        })
-        .max()
-        .expect("There must be at lest one sentene")
+fn most_words_found(sentences: &[String]) -> Option<usize> {
+    sentences.iter().map(|x| x.split_whitespace().count()).max()
 }
 
 pub fn solve() {
@@ -15,6 +9,8 @@ pub fn solve() {
         "i think so too".to_string(),
         "this is great thanks very much".to_string(),
     ];
-    let result = most_words_found(&sentences);
-    println!("Max number of words found: {result}");
+    match most_words_found(&sentences) {
+        Some(result) => println!("The max number of words found is : {result:?}"),
+        None => println!("Error: Empty input"),
+    }
 }

--- a/src/problem15.rs
+++ b/src/problem15.rs
@@ -1,34 +1,35 @@
-// Problem 15. Sorting the Sentence
-fn sort_sentence(s: &str) -> String {
+fn sort_sentence(s: &str) -> Result<String, String> {
     let words: Vec<&str> = s.split_whitespace().collect();
+    if words.is_empty() {
+        return Err("Error: Empty input vector".to_string());
+    }
 
-    let mut words_with_index: Vec<(usize, &str)> = words
+    let words_with_index: Vec<(usize, &str)> = words
         .iter()
-        .map(|x| {
-            let index = usize::try_from(
-                x.chars()
-                    .last()
-                    .expect("Each word has at aleast one character")
-                    .to_digit(10)
-                    .expect("Failed to convert char to digit"),
-            )
-            .expect("Failed to convert digit to usize");
-            let words_stripped = &x[..x.len() - 1];
-            (index, words_stripped)
+        .filter_map(|&word| {
+            let (body, index_part) = word.split_at(word.len().saturating_sub(1));
+            index_part.parse::<usize>().ok().map(|index| (index, body))
         })
         .collect();
 
+    if words_with_index.len() != words.len() {
+        return Err("Error: Some words are missing a valid index".to_string());
+    }
+
+    let mut words_with_index = words_with_index;
     words_with_index.sort_unstable_by_key(|&(index, _)| index);
-    let result: String = words_with_index
+
+    Ok(words_with_index
         .iter()
         .map(|&(_, word)| word)
         .collect::<Vec<&str>>()
-        .join(" ");
-    result
+        .join(" "))
 }
 
 pub fn solve() {
-    let s: String = "is2 sentence4 This1 a3".to_string();
-    let result = sort_sentence(&s);
-    println!("Sorted sentence: {result}");
+    let s1: &str = "is2 sentence4 This1 a3";
+    match sort_sentence(s1) {
+        Ok(result) => println!("The sorted sentence is : {result}"),
+        Err(e) => println!("{e}"),
+    }
 }

--- a/src/problem17.rs
+++ b/src/problem17.rs
@@ -2,7 +2,11 @@
 fn decode(encoded: &[i32], first: i32) -> Vec<i32> {
     let mut result = vec![first];
     for &val in encoded {
-        result.push(result.last().expect("Empty vector") ^ val);
+        result.push(
+            result.last().expect(
+                "Result vector has at least one element, which is initialized with the first",
+            ) ^ val,
+        );
     }
     result
 }

--- a/src/problem20.rs
+++ b/src/problem20.rs
@@ -1,33 +1,33 @@
 // Problem 20 - Decode the Message
+use std::char::TryFromCharError;
 use std::collections::HashMap;
-fn decode_message(key: &str, message: &str) -> String {
+fn decode_message(key: &str, message: &str) -> Result<String, TryFromCharError> {
     let mut char_map: HashMap<char, char> = HashMap::new();
     let mut next_char = 'a';
 
     for ch in key.chars() {
         if ch != ' ' && !char_map.contains_key(&ch) {
             char_map.insert(ch, next_char);
-            next_char = char::from(u8::try_from(next_char).expect("Can't convert char to u8") + 1);
+            next_char = char::from(u8::try_from(next_char)? + 1);
         }
     }
 
-    message
+    Ok(message
         .chars()
-        .map(|ch| {
-            if ch == ' ' {
-                ' '
-            } else {
-                *char_map
-                    .get(&ch)
-                    .expect("Input should be only lowercase alphabets and whitespaces")
-            }
-        })
-        .collect()
+        .map(|ch| *char_map.get(&ch).unwrap_or(&' '))
+        .collect())
 }
 
 pub fn solve() {
     let key = "the quick brown fox jumps over the lazy dog";
     let message = "vkbs bs t suepuv";
-    let result = decode_message(key, message);
-    println!("Decoded message: {result}");
+    match decode_message(key, message) {
+        Ok(result) => {
+            println!("Decoded result: {result}");
+        }
+
+        Err(e) => {
+            println!("Error: {e}");
+        }
+    }
 }

--- a/src/problem5.rs
+++ b/src/problem5.rs
@@ -1,13 +1,12 @@
 // Problem 5. Richest Customer Wealth
-fn find_maxwealth(accounts: &[Vec<i32>]) -> i32 {
-    accounts
-        .iter()
-        .map(|x| x.iter().sum())
-        .max()
-        .expect("No elements in the vector")
+fn find_maxwealth(accounts: &[Vec<i32>]) -> Option<i32> {
+    accounts.iter().map(|acc| acc.iter().sum()).max()
 }
+
 pub fn solve() {
     let accounts = vec![vec![1, 5], vec![7, 3], vec![3, 5]];
-    let max_wealth = find_maxwealth(&accounts);
-    println!("The maximum wealth is {max_wealth}");
+    match find_maxwealth(&accounts) {
+        Some(val) => println!("The maximum wealth is {val}"),
+        None => println!("Error: Empty input"),
+    }
 }

--- a/src/problem7.rs
+++ b/src/problem7.rs
@@ -1,27 +1,17 @@
-fn minimum_sum(num: i32) -> i32 {
-    let num_string = num.to_string();
-    let mut digits: Vec<i32> = num_string
+fn minimum_sum(num: i32) -> Result<u32, String> {
+    let s = num.to_string();
+    let mut digits: Vec<u32> = s
         .chars()
-        .map(|x| {
-            x.to_string()
-                .parse::<i32>()
-                .expect("Invalid input. Must use positive integer consisting of four digits.")
-        })
-        .collect();
+        .map(|c| c.to_digit(10).ok_or("Invalid digit".to_string()))
+        .collect::<Result<Vec<u32>, String>>()?;
     digits.sort_unstable();
-
-    let small1 = digits[0];
-    let small2 = digits[1];
-    let large1 = digits[2];
-    let large2 = digits[3];
-
-    let result: i32 = 10 * (small1 + small2) + large1 + large2;
-
-    result
+    Ok(10 * (digits[0] + digits[1]) + digits[2] + digits[3])
 }
 
 pub fn solve() {
-    let num = 3524;
-    let sum = minimum_sum(num);
-    println!("The minimum sum of two numbers is: {sum}");
+    let num = 5234;
+    match minimum_sum(num) {
+        Ok(sum) => println!("The minimum sum is: {sum}"),
+        Err(e) => println!("Error: {e}"),
+    }
 }

--- a/src/problem9.rs
+++ b/src/problem9.rs
@@ -1,16 +1,19 @@
 // Problem 9. Kids With the Greatest Number of Candies
-fn kids_with_candies(candies: &[i32], extra_candies: i32) -> Vec<bool> {
-    let max_value = *candies.iter().max().expect("No elements in the vector");
-    let result: Vec<bool> = candies
-        .iter()
-        .map(|x| x + extra_candies >= max_value)
-        .collect();
-    result
+fn kids_with_candies(candies: &[i32], extra_candies: i32) -> Option<Vec<bool>> {
+    let &max_value = candies.iter().max()?;
+    Some(
+        candies
+            .iter()
+            .map(|&c| c + extra_candies >= max_value)
+            .collect(),
+    )
 }
 
 pub fn solve() {
-    let candies: Vec<i32> = vec![2, 3, 5, 1, 3];
-    let extra_candies: i32 = 3;
-    let result = kids_with_candies(&candies, extra_candies);
-    println!("{result:?}");
+    let candies = vec![1, 4, 2, 5];
+    let extra_candies = 3;
+    match kids_with_candies(&candies, extra_candies) {
+        Some(result) => println!("The result array is : {result:?}"),
+        None => println!("Error: Empty input"),
+    }
 }


### PR DESCRIPTION
Use the expect() method only in scenarios where panic is not possible. Minimize expect() usage by converting return types to Result or Option when feasible. Annotate each expect() call with a clear explanation to guarantee that panic will not occur.

Close: #78 